### PR TITLE
:ambulance: Refresh chat object to track analytics consent

### DIFF
--- a/handler/payloadAnalytics.js
+++ b/handler/payloadAnalytics.js
@@ -14,6 +14,8 @@ export async function accept(chat) {
 
     const thanksAnalytics = await getFaq(chat, 'thanksAnalytics');
 
+    await chat.loadSettings();
+
     await chat.track.event('Analytics', 'Allowed', chat.language).send();
 
     return chat.sendFragments(thanksAnalytics.fragments);


### PR DESCRIPTION
Well, uuad is set just if tracking is enabled. Thus, settings have to be refreshed in order to be able to track giving consent.