### PR TITLE
:sparkles: Reply to Messenger-Lite user with defaultReplyTriggerMessage

### DIFF
--- a/entrypoint/fb.js
+++ b/entrypoint/fb.js
@@ -79,7 +79,12 @@ const sendDefaultReply = async (chat) => {
         const lastReply = await lastDefaultReplies.load(chat.psid);
         sendReply = lastReply.ttl <= Math.floor(Date.now() / 1000);
     } catch {
-        sendReply = true;
+        const subscriptions = new DynamoDbCrud(process.env.DYNAMODB_SUBSCRIPTIONS)
+        if (await subscriptions.load(chat.psid)) {
+            sendReply = true;
+        } else {
+            sendReply = false;
+        }
     }
 
     if (sendReply) {

--- a/entrypoint/fb.js
+++ b/entrypoint/fb.js
@@ -79,12 +79,8 @@ const sendDefaultReply = async (chat) => {
         const lastReply = await lastDefaultReplies.load(chat.psid);
         sendReply = lastReply.ttl <= Math.floor(Date.now() / 1000);
     } catch {
-        const subscriptions = new DynamoDbCrud(process.env.DYNAMODB_SUBSCRIPTIONS)
-        if (await subscriptions.load(chat.psid)) {
-            sendReply = true;
-        } else {
-            sendReply = false;
-        }
+        const tracking = new DynamoDbCrud(process.env.DYNAMODB_TRACKING);
+        sendReply = chat.subscribed || await tracking.load(chat.psid);
     }
 
     if (sendReply) {


### PR DESCRIPTION
Messenger-Lite User aren't able to interact with buttons nor quick replies.

We check, wether the user subscribed for our service or not. If not, they receive the trigger message.